### PR TITLE
Add logging of start and end times of inference to matching runtime

### DIFF
--- a/runtime/entrypoint.sh
+++ b/runtime/entrypoint.sh
@@ -29,7 +29,9 @@ exit_code=0
     if [ -f "main.py" ]
     then
         echo "Generating matches on a subset of query videos..."
+        echo "Started at $(date -u +'%Y-%m-%dT%H:%M:%SZ') ($(date +%s))"
         conda run --no-capture-output -n condaenv python main.py
+        echo "Finished at $(date -u +'%Y-%m-%dT%H:%M:%SZ') ($(date +%s))"
 
         echo "Validating matches subset..."
         conda run --no-capture-output -n condaenv \


### PR DESCRIPTION
Similar to what we did for the descriptor runtime, this PR adds logging of start and end of inference time to the entrypoint script